### PR TITLE
corrected misleading variable name

### DIFF
--- a/rbiparser/__init__.py
+++ b/rbiparser/__init__.py
@@ -48,7 +48,7 @@ banks_list_filename = "banks.json"
 filters_filename = "filters.json"
 
 # Regex
-alphanumeric = re.compile(r"[^a-z0-9]", re.IGNORECASE)
+non_alphanumeric = re.compile(r"[^a-z0-9]", re.IGNORECASE)
 spaces = re.compile(r"(\s+)")
 brackets = re.compile(r"([^\s])(\()(.+?)(\))([a-z0-9])?")
 punctuations = re.compile(r"([{}\s])\1+".format(string.punctuation))

--- a/rbiparser/__init__.py
+++ b/rbiparser/__init__.py
@@ -311,7 +311,7 @@ def clean_row(row, filters=False):
 	row[6] = clean_line(row[6], True)
 	row[7] = clean_line(row[7], True)
 
-	if len(alphanumeric.sub("", row[7])) < 4:
+	if len(non_alphanumeric.sub("", row[7])) < 4:
 		row[7] = row[6]
 
 	row[8] = clean_line(row[8])
@@ -340,7 +340,7 @@ def clean_line(line, complicated=False):
 	# Uppercase potential abbreviations.
 	chunks = line.split(" ")
 	for n, c in enumerate(chunks):
-		if len(alphanumeric.sub("", c)) >= 3 and c not in exclude_words:
+		if len(non_alphanumeric.sub("", c)) >= 3 and c not in exclude_words:
 			chunks[n] = c.title()
 		else:
 			chunks[n] = c.upper()


### PR DESCRIPTION
When we define `^` in a square bracket it negate the matches.
Example:
`[^abc]` : matches any char except a, b or c.
`[^a-z]` : matches any character except lower alphabets
`[^a-z0-9]` : matches any character except lower alphabets and numbers

So changed name of variable to `non_alphanumeric`.
Here I have created playground for same scenario: https://regex101.com/r/zmEBu2/1
