### PR TITLE
Adding exceptions

### DIFF
--- a/rbiparser/__init__.py
+++ b/rbiparser/__init__.py
@@ -25,6 +25,8 @@ import os
 import glob
 import string
 
+from rbiparser.exceptions import RBIParserError, DownloadError, ParseError, StorageError
+
 try:
 	from urlparse import urlparse
 except ImportError:
@@ -73,14 +75,14 @@ def get_sheet_urls(url):
 	"""Scrapes the RBI page and gets the list of .xlsx sheets."""
 	r = requests.get(url)
 	if r.status_code != 200:
-		raise Exception("Invalid response from", url)
+		raise DownloadError(f"Invalid response from {url}")
 
 	# Extract the urls.
 	s = soup(r.content, "lxml")
 	links = s.findAll("a", href=re.compile("\.xlsx$"))
 
 	if len(links) < 1:
-		raise Exception("Couldn't find any .xlsx urls")
+		raise ParseError("Couldn't find any .xlsx urls")
 
 	return [l["href"] for l in links]
 
@@ -90,7 +92,7 @@ def convert_xlsx_to_csv(src, target, headers):
 	try:
 		sheet = xlrd.open_workbook(src).sheet_by_index(0)
 	except Exception as e:
-		raise Exception("Can't open sheet.", str(e))
+		raise ParseError(f"Can't open sheet: {e}")
 
 	with open(target, "wb") as cf:
 		writer = csv.writer(cf, quoting=csv.QUOTE_ALL)
@@ -108,11 +110,11 @@ def convert_xlsx_to_csv(src, target, headers):
 					first = True
 
 					if len(vals) != len(headers):
-						raise Exception("Headers don't match.")
+						raise ParseError("Headers don't match")
 
 				writer.writerow(vals)
 		except Exception as e:
-			raise Exception("Can't convert sheet.", str(e))
+			raise ParseError(f"Can't convert sheet: {e}")
 
 
 def url_to_file(url):
@@ -135,7 +137,7 @@ def save_etags(etags, fname):
 		with open(fname, "w") as f:
 			f.write(json.dumps(etags, indent=4))
 	except Exception as e:
-		raise Exception("Could not write to " + fname + ": " + str(e))
+		raise StorageError(f"Could not write to {fname}: {e}")
 
 
 def get_url_headers(url):
@@ -144,7 +146,7 @@ def get_url_headers(url):
 		r = requests.head(url)
 		return r.headers
 	except Exception as e:
-		raise Exception("Can't reach", url, ": ", str(e))
+		raise DownloadError(f"Can't reach {url}: {e}")
 
 
 def download(url, target):
@@ -153,7 +155,7 @@ def download(url, target):
 		r = requests.get(url, stream=True)
 		r.raw.decode_content = True
 	except Exception as e:
-		raise Exception("Can't download", url, ": ", str(e))
+		raise DownloadError(f"Can't download {url}: {e}")
 
 	try:
 		with open(target, "wb") as f:
@@ -161,7 +163,7 @@ def download(url, target):
 				if chunk:
 					f.write(chunk)
 	except Exception as e:
-		raise Exception("Can't write ", target, ": ", str(e))
+		raise StorageError(f"Can't write to {target}: {e}")
 
 	return {
 		"etag": r.headers.get("etag", ""),

--- a/rbiparser/console.py
+++ b/rbiparser/console.py
@@ -1,5 +1,6 @@
 import click
 import rbiparser as rbi
+from rbiparser.exceptions import RBIParserError
 
 SOURCE_URL = "https://www.rbi.org.in/scripts/bs_viewcontent.aspx?Id=2009"
 
@@ -20,7 +21,10 @@ def cli():
 	help="Etags file")
 def download(source, dest, etag):
 	"""Download all listed bank documents from RBI as .xlsx format."""
-	rbi.download_all(source, dest, etag)
+	try:
+		rbi.download_all(source, dest, etag)
+	except RBIParserError as e:
+		raise click.ClickException(str(e))
 
 
 @cli.command()
@@ -30,7 +34,10 @@ def download(source, dest, etag):
 	help="Target directory for CSV files.")
 def convert(source, dest):
 	"""Convert all xls documents to CSV"""
-	rbi.convert_all(source, dest, rbi.HEADERS)
+	try:
+		rbi.convert_all(source, dest, rbi.HEADERS)
+	except RBIParserError as e:
+		raise click.ClickException(str(e))
 
 
 @cli.command()

--- a/rbiparser/exceptions.py
+++ b/rbiparser/exceptions.py
@@ -1,0 +1,29 @@
+class RBIParserError(Exception):
+    """Base exception for all rbiparser errors.
+    Catch this to handle any error from the library."""
+    pass
+
+
+class DownloadError(RBIParserError):
+    """Raised when downloading files from the RBI website fails."""
+    pass
+
+
+class ParseError(RBIParserError):
+    """Raised when parsing or converting an Excel/CSV file fails."""
+    pass
+
+
+class ValidationError(RBIParserError):
+    """Raised when input arguments or data fail validation."""
+    pass
+
+
+class StorageError(RBIParserError):
+    """Raised when reading or writing files to disk fails."""
+    pass
+
+
+class CombineError(RBIParserError):
+    """Raised when combining CSV files fails."""
+    pass


### PR DESCRIPTION
Issue Resolved : [Link](https://github.com/zerodha/rbiparser/issues/15)

Description -

## Replace generic exceptions with typed custom exceptions

### Summary
Replaces all 9 bare `raise Exception(...)` calls in __init__.py with typed exceptions from `rbiparser.exceptions`, making errors easier to catch and handle programmatically.

### Changes

**exceptions.py**

created class to include exceptions

**__init__.py**

| Function | Exception raised |
|---|---|
| `get_sheet_urls` – bad HTTP status | `DownloadError` |
| `get_sheet_urls` – no `.xlsx` links found | `ParseError` |
| `convert_xlsx_to_csv` – workbook can't be opened | `ParseError` |
| `convert_xlsx_to_csv` – header column mismatch | `ParseError` |
| `convert_xlsx_to_csv` – sheet conversion fails | `ParseError` |
| `save_etags` – file write failure | `StorageError` |
| `get_url_headers` – network error | `DownloadError` |
| `download` – fetch failure | `DownloadError` |
| `download` – disk write failure | `StorageError` |

### Bug fixes (incidental)
Four of the original raises used the multi-argument form `Exception("msg", var, ...)`, which stores a tuple in `args[0]` rather than a human-readable string. All are now f-strings.

### Why
Callers can now distinguish between a network failure (`DownloadError`), a malformed file (`ParseError`), and an I/O problem (`StorageError`) without parsing exception message strings. All three are subclasses of `RBIParserError`, so existing broad `except RBIParserError` handlers are unaffected.